### PR TITLE
CI-935 Bug - Empty terms when no terms are assigned to posts

### DIFF
--- a/lib/inc/class-wp-rest-coauthors-authorterms.php
+++ b/lib/inc/class-wp-rest-coauthors-authorterms.php
@@ -238,7 +238,7 @@ class WP_REST_CoAuthors_AuthorTerms extends WP_REST_Controller {
 
 		if ( empty( $terms ) ) {
 			//Nothing was returned, that shouldn't happen unless a requested post doesn't have any guest-authors
-			return new WP_Error( 'rest_authors_get_term', __( 'No terms returned for "'.$this->coauthor_taxonomy.'" taxonomy.'  ), array( 'status' => 404 ) );
+			return new WP_Error( 'rest_authors_get_term', __( 'No terms returned for "'.$this->coauthor_taxonomy.'" taxonomy.' ), array( 'status' => 404 ) );
 		}
 
 		foreach ( $terms as $term ) {

--- a/lib/inc/class-wp-rest-coauthors-authorterms.php
+++ b/lib/inc/class-wp-rest-coauthors-authorterms.php
@@ -228,7 +228,7 @@ class WP_REST_CoAuthors_AuthorTerms extends WP_REST_Controller {
 			$terms = wp_get_object_terms( $parent_id, $this->coauthor_taxonomy );
 		} else {
 			//Get all 'author' terms
-			$terms = get_terms( $this->coauthor_taxonomy );
+			$terms = get_terms( $this->coauthor_taxonomy, array( 'hide_empty' => 0 ) );
 		}
 
 		if ( is_wp_error( $terms ) ) {
@@ -238,7 +238,7 @@ class WP_REST_CoAuthors_AuthorTerms extends WP_REST_Controller {
 
 		if ( empty( $terms ) ) {
 			//Nothing was returned, that shouldn't happen unless a requested post doesn't have any guest-authors
-			return new WP_Error( 'rest_authors_get_term', __( 'No terms returned.' ), array( 'status' => 404 ) );
+			return new WP_Error( 'rest_authors_get_term', __( 'No terms returned for "'.$this->coauthor_taxonomy.'" taxonomy.'  ), array( 'status' => 404 ) );
 		}
 
 		foreach ( $terms as $term ) {

--- a/wp-api-co-author-plus-endpoints.php
+++ b/wp-api-co-author-plus-endpoints.php
@@ -4,7 +4,7 @@
  * Description: WP REST API companion plugin for Co-Authors Plus endpoints
  * Author: Michael Jacobsen
  * Author URI: https://mjacobsen4dfm.wordpress.com/
- * Version: 0.1.1
+ * Version: 0.1.2
  * Plugin URI: https://github.com/mjacobsen4DFM/wp-api-co-author-plus-endpoints
  * License: GPL2+
  */


### PR DESCRIPTION
By default, get_terms() hides terms not assigned to any posts.
- Added an argument to disable that options: 'hide_empty' => 0
- Also, added a string dump to verify that $coauthor_taxonomy has the
  correct value.
