### PR TITLE
CI-1888 : Revise permission checks for Co-Authors Plus Endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,9 @@ https://github.com/Automattic/Co-Authors-Plus
 
 ### 0.1.1 (March 23, 2016) ###
 * Production Release
+
+### 0.1.2 (March 28, 2016) ###
+* Bug fix: Empty terms when no terms are assigned to posts
+
+### 0.1.3 (Aug 23, 2016) ###
+* Usability update: Revise permission checks for Co-Authors Plus Endpoints

--- a/lib/endpoints/class-wp-rest-coauthors-authorposts-endpoint.php
+++ b/lib/endpoints/class-wp-rest-coauthors-authorposts-endpoint.php
@@ -56,18 +56,7 @@ class WP_REST_CoAuthors_AuthorPosts_Endpoint extends WP_REST_CoAuthors_AuthorPos
 		$this->rest_base         = 'author-posts';
 		parent::__construct();
 	}
-
-	/**
-	 * Check if a given request has access to get a specific authors entry for a post.
-	 *
-	 * @param WP_REST_Request $request Full data about the request.
-	 *
-	 * @return boolean|WP_Error
-	 */
-	public function get_item_permissions_check( $request ) {
-		return $this->get_items_permissions_check( $request );
-	}
-
+	
 	/**
 	 * Check if a given request has access to get authors for a post.
 	 *
@@ -83,15 +72,6 @@ class WP_REST_CoAuthors_AuthorPosts_Endpoint extends WP_REST_CoAuthors_AuthorPos
 				return new WP_Error( 'rest_post_invalid_id', __( 'Invalid post id.' ), array( 'status' => 404 ) );
 			}
 
-			if ( ! $this->parent_controller->check_read_permission( $parent ) ) {
-				return new WP_Error( 'rest_forbidden', __( 'Sorry, you cannot view this post.' ), array( 'status' => rest_authorization_required_code() ) );
-			}
-
-			$post_type = get_post_type_object( $parent->post_type );
-			if ( ! current_user_can( $post_type->cap->edit_post, $parent->ID ) ) {
-				return new WP_Error( 'rest_forbidden', __( 'Sorry, you cannot view the authors for this post.' ), array( 'status' => rest_authorization_required_code() ) );
-			}
-
 			return true;
 		}
 
@@ -99,25 +79,55 @@ class WP_REST_CoAuthors_AuthorPosts_Endpoint extends WP_REST_CoAuthors_AuthorPos
 	}
 
 	/**
-	 * Check if a given request has access to create a authors entry for a post.
+	 * Check if a given request has access to create an author association for a post.
 	 *
 	 * @param WP_REST_Request $request Full data about the request.
 	 *
 	 * @return boolean
 	 */
 	public function create_item_permissions_check( $request ) {
-		return $this->get_items_permissions_check( $request );
+		if ( ! empty( $request['parent_id'] ) ) {
+			$parent = get_post( (int) $request['parent_id'] );
+
+			if ( empty( $parent ) || empty( $parent->ID ) ) {
+				return new WP_Error( 'rest_post_invalid_id', __( 'Invalid post id.' ), array( 'status' => 404 ) );
+			}
+
+			$post_type = get_post_type_object( $parent->post_type );
+			if ( ! current_user_can( $post_type->cap->edit_post, $parent->ID ) ) {
+				return new WP_Error( 'rest_forbidden', __( 'Sorry, you cannot create an author association for this post.' ), array( 'status' => rest_authorization_required_code() ) );
+			}
+
+			return true;
+		}
+
+		return new WP_Error( 'rest_forbidden', __( 'Creating an author is not supported.' ), array( 'status' => rest_authorization_required_code() ) );
 	}
 
 	/**
-	 * Check if a given request has access to update a authors entry for a post.
+	 * Check if a given request has access to update the author association for a post.
 	 *
 	 * @param WP_REST_Request $request Full data about the request.
 	 *
 	 * @return boolean
 	 */
 	public function update_item_permissions_check( $request ) {
-		return $this->get_items_permissions_check( $request );
+		if ( ! empty( $request['parent_id'] ) ) {
+			$parent = get_post( (int) $request['parent_id'] );
+
+			if ( empty( $parent ) || empty( $parent->ID ) ) {
+				return new WP_Error( 'rest_post_invalid_id', __( 'Invalid post id.' ), array( 'status' => 404 ) );
+			}
+
+			$post_type = get_post_type_object( $parent->post_type );
+			if ( ! current_user_can( $post_type->cap->edit_post, $parent->ID ) ) {
+				return new WP_Error( 'rest_forbidden', __( 'Sorry, you cannot update the author association for this post.' ), array( 'status' => rest_authorization_required_code() ) );
+			}
+
+			return true;
+		}
+
+		return new WP_Error( 'rest_forbidden', __( 'Updating an author is not supported.' ), array( 'status' => rest_authorization_required_code() ) );
 	}
 
 	/**
@@ -128,6 +138,6 @@ class WP_REST_CoAuthors_AuthorPosts_Endpoint extends WP_REST_CoAuthors_AuthorPos
 	 * @return boolean, always false: delete is not supported
 	 */
 	public function delete_item_permissions_check( $request ) {
-		return false;
+		return new WP_Error( 'rest_forbidden', __( 'Deleting an author is not supported.' ), array( 'status' => rest_authorization_required_code() ) );
 	}
 }

--- a/lib/endpoints/class-wp-rest-coauthors-authorterms-endpoint.php
+++ b/lib/endpoints/class-wp-rest-coauthors-authorterms-endpoint.php
@@ -58,17 +58,6 @@ class WP_REST_CoAuthors_AuthorTerms_Endpoint extends WP_REST_CoAuthors_AuthorTer
 	}
 
 	/**
-	 * Check if a given request has access to get a specific authors entry for a post.
-	 *
-	 * @param WP_REST_Request $request Full data about the request.
-	 *
-	 * @return boolean|WP_Error
-	 */
-	public function get_item_permissions_check( $request ) {
-		return $this->get_items_permissions_check( $request );
-	}
-
-	/**
 	 * Check if a given request has access to get authors for a post.
 	 *
 	 * @param WP_REST_Request $request Full data about the request.
@@ -83,15 +72,6 @@ class WP_REST_CoAuthors_AuthorTerms_Endpoint extends WP_REST_CoAuthors_AuthorTer
 				return new WP_Error( 'rest_post_invalid_id', __( 'Invalid post id.' ), array( 'status' => 404 ) );
 			}
 
-			if ( ! $this->parent_controller->check_read_permission( $parent ) ) {
-				return new WP_Error( 'rest_forbidden', __( 'Sorry, you cannot view this post.' ), array( 'status' => rest_authorization_required_code() ) );
-			}
-
-			$post_type = get_post_type_object( $parent->post_type );
-			if ( ! current_user_can( $post_type->cap->edit_post, $parent->ID ) ) {
-				return new WP_Error( 'rest_forbidden', __( 'Sorry, you cannot view the authors for this post.' ), array( 'status' => rest_authorization_required_code() ) );
-			}
-
 			return true;
 		}
 
@@ -99,25 +79,55 @@ class WP_REST_CoAuthors_AuthorTerms_Endpoint extends WP_REST_CoAuthors_AuthorTer
 	}
 
 	/**
-	 * Check if a given request has access to create a authors entry for a post.
+	 * Check if a given request has access to create an author association for a post.
 	 *
 	 * @param WP_REST_Request $request Full data about the request.
 	 *
 	 * @return boolean
 	 */
 	public function create_item_permissions_check( $request ) {
-		return $this->get_items_permissions_check( $request );
+		if ( ! empty( $request['parent_id'] ) ) {
+			$parent = get_post( (int) $request['parent_id'] );
+
+			if ( empty( $parent ) || empty( $parent->ID ) ) {
+				return new WP_Error( 'rest_post_invalid_id', __( 'Invalid post id.' ), array( 'status' => 404 ) );
+			}
+
+			$post_type = get_post_type_object( $parent->post_type );
+			if ( ! current_user_can( $post_type->cap->edit_post, $parent->ID ) ) {
+				return new WP_Error( 'rest_forbidden', __( 'Sorry, you cannot create an author association for this post.' ), array( 'status' => rest_authorization_required_code() ) );
+			}
+
+			return true;
+		}
+
+		return new WP_Error( 'rest_forbidden', __( 'Creating an author is not supported.' ), array( 'status' => rest_authorization_required_code() ) );
 	}
 
 	/**
-	 * Check if a given request has access to update a authors entry for a post.
+	 * Check if a given request has access to update the author association for a post.
 	 *
 	 * @param WP_REST_Request $request Full data about the request.
 	 *
 	 * @return boolean
 	 */
 	public function update_item_permissions_check( $request ) {
-		return $this->get_items_permissions_check( $request );
+		if ( ! empty( $request['parent_id'] ) ) {
+			$parent = get_post( (int) $request['parent_id'] );
+
+			if ( empty( $parent ) || empty( $parent->ID ) ) {
+				return new WP_Error( 'rest_post_invalid_id', __( 'Invalid post id.' ), array( 'status' => 404 ) );
+			}
+
+			$post_type = get_post_type_object( $parent->post_type );
+			if ( ! current_user_can( $post_type->cap->edit_post, $parent->ID ) ) {
+				return new WP_Error( 'rest_forbidden', __( 'Sorry, you cannot update the author association for this post.' ), array( 'status' => rest_authorization_required_code() ) );
+			}
+
+			return true;
+		}
+
+		return new WP_Error( 'rest_forbidden', __( 'Updating an author is not supported.' ), array( 'status' => rest_authorization_required_code() ) );
 	}
 
 	/**
@@ -128,6 +138,6 @@ class WP_REST_CoAuthors_AuthorTerms_Endpoint extends WP_REST_CoAuthors_AuthorTer
 	 * @return boolean, always false: delete is not supported
 	 */
 	public function delete_item_permissions_check( $request ) {
-		return false;
+		return new WP_Error( 'rest_forbidden', __( 'Deleting an author is not supported.' ), array( 'status' => rest_authorization_required_code() ) );
 	}
 }

--- a/lib/endpoints/class-wp-rest-coauthors-authorusers-endpoint.php
+++ b/lib/endpoints/class-wp-rest-coauthors-authorusers-endpoint.php
@@ -58,17 +58,6 @@ class WP_REST_CoAuthors_AuthorUsers_Endpoint extends WP_REST_CoAuthors_AuthorUse
 	}
 
 	/**
-	 * Check if a given request has access to get a specific authors entry for a post.
-	 *
-	 * @param WP_REST_Request $request Full data about the request.
-	 *
-	 * @return boolean|WP_Error
-	 */
-	public function get_item_permissions_check( $request ) {
-		return $this->get_items_permissions_check( $request );
-	}
-
-	/**
 	 * Check if a given request has access to get authors for a post.
 	 *
 	 * @param WP_REST_Request $request Full data about the request.
@@ -83,15 +72,6 @@ class WP_REST_CoAuthors_AuthorUsers_Endpoint extends WP_REST_CoAuthors_AuthorUse
 				return new WP_Error( 'rest_post_invalid_id', __( 'Invalid post id.' ), array( 'status' => 404 ) );
 			}
 
-			if ( ! $this->parent_controller->check_read_permission( $parent ) ) {
-				return new WP_Error( 'rest_forbidden', __( 'Sorry, you cannot view this post.' ), array( 'status' => rest_authorization_required_code() ) );
-			}
-
-			$post_type = get_post_type_object( $parent->post_type );
-			if ( ! current_user_can( $post_type->cap->edit_post, $parent->ID ) ) {
-				return new WP_Error( 'rest_forbidden', __( 'Sorry, you cannot view the authors for this post.' ), array( 'status' => rest_authorization_required_code() ) );
-			}
-
 			return true;
 		}
 
@@ -99,25 +79,55 @@ class WP_REST_CoAuthors_AuthorUsers_Endpoint extends WP_REST_CoAuthors_AuthorUse
 	}
 
 	/**
-	 * Check if a given request has access to create a authors entry for a post.
+	 * Check if a given request has access to create an author association for a post.
 	 *
 	 * @param WP_REST_Request $request Full data about the request.
 	 *
 	 * @return boolean
 	 */
 	public function create_item_permissions_check( $request ) {
-		return $this->get_items_permissions_check( $request );
+		if ( ! empty( $request['parent_id'] ) ) {
+			$parent = get_post( (int) $request['parent_id'] );
+
+			if ( empty( $parent ) || empty( $parent->ID ) ) {
+				return new WP_Error( 'rest_post_invalid_id', __( 'Invalid post id.' ), array( 'status' => 404 ) );
+			}
+
+			$post_type = get_post_type_object( $parent->post_type );
+			if ( ! current_user_can( $post_type->cap->edit_post, $parent->ID ) ) {
+				return new WP_Error( 'rest_forbidden', __( 'Sorry, you cannot create an author association for this post.' ), array( 'status' => rest_authorization_required_code() ) );
+			}
+
+			return true;
+		}
+
+		return new WP_Error( 'rest_forbidden', __( 'Creating an author is not supported.' ), array( 'status' => rest_authorization_required_code() ) );
 	}
 
 	/**
-	 * Check if a given request has access to update a authors entry for a post.
+	 * Check if a given request has access to update the author association for a post.
 	 *
 	 * @param WP_REST_Request $request Full data about the request.
 	 *
 	 * @return boolean
 	 */
 	public function update_item_permissions_check( $request ) {
-		return $this->get_items_permissions_check( $request );
+		if ( ! empty( $request['parent_id'] ) ) {
+			$parent = get_post( (int) $request['parent_id'] );
+
+			if ( empty( $parent ) || empty( $parent->ID ) ) {
+				return new WP_Error( 'rest_post_invalid_id', __( 'Invalid post id.' ), array( 'status' => 404 ) );
+			}
+
+			$post_type = get_post_type_object( $parent->post_type );
+			if ( ! current_user_can( $post_type->cap->edit_post, $parent->ID ) ) {
+				return new WP_Error( 'rest_forbidden', __( 'Sorry, you cannot update the author association for this post.' ), array( 'status' => rest_authorization_required_code() ) );
+			}
+
+			return true;
+		}
+
+		return new WP_Error( 'rest_forbidden', __( 'Updating an author is not supported.' ), array( 'status' => rest_authorization_required_code() ) );
 	}
 
 	/**
@@ -128,6 +138,7 @@ class WP_REST_CoAuthors_AuthorUsers_Endpoint extends WP_REST_CoAuthors_AuthorUse
 	 * @return boolean, always false: delete is not supported
 	 */
 	public function delete_item_permissions_check( $request ) {
-		return false;
+		return new WP_Error( 'rest_forbidden', __( 'Deleting an author is not supported.' ), array( 'status' => rest_authorization_required_code() ) );
 	}
 }
+

--- a/wp-api-co-author-plus-endpoints.php
+++ b/wp-api-co-author-plus-endpoints.php
@@ -4,7 +4,7 @@
  * Description: WP REST API companion plugin for Co-Authors Plus endpoints
  * Author: Michael Jacobsen
  * Author URI: https://mjacobsen4dfm.wordpress.com/
- * Version: 0.1.1
+ * Version: 0.1.3
  * Plugin URI: https://github.com/mjacobsen4DFM/wp-api-co-author-plus-endpoints
  * License: GPL2+
  */


### PR DESCRIPTION
~Remove permission checks for read-only access to authors
~Add permission checks for post edit permissions when creating a post's
author association; else throw error
~Add permission checks for post edit permissions when updating a post's
author association; else throw error
~Add error message for deleting an author attempt
~Removed extraneous get_item_permissions_check() function
~Cleaned up some comments and messages
~Update readme and init to reflect version 0.1.3
