### PR TITLE
CI-2204 - Adding pagination / max results to endpoints

### DIFF
--- a/lib/inc/class-wp-rest-coauthors-authorposts.php
+++ b/lib/inc/class-wp-rest-coauthors-authorposts.php
@@ -94,7 +94,7 @@ class WP_REST_CoAuthors_AuthorPosts extends WP_REST_Controller {
 			'taxonomy' => $taxonomy,
 			'hide_empty' => false,
 			'number' => $number,
-			'offset' => $offset
+			'offset' => $offset,
 		);
 
 		//Populate the $author_terms(), so that we can pull out the applicable 'author-posts'

--- a/lib/inc/class-wp-rest-coauthors-authorposts.php
+++ b/lib/inc/class-wp-rest-coauthors-authorposts.php
@@ -84,6 +84,19 @@ class WP_REST_CoAuthors_AuthorPosts extends WP_REST_Controller {
 
 		$authors = array();
 
+		// If number and offset are set in the $request, use them,
+		// otherwise default to show 100
+		$number = ! empty( $request['number'] && 100 >= $request['number'] ) ? $request['number'] : 100;
+		$offset = ! empty( $request['offset'] ) ? $request['offset'] : 0;
+		$taxonomy = ! empty( $this->coauthor_taxonomy ) ? $this->coauthor_taxonomy : 'author';
+
+		$query_args = array(
+			'taxonomy' => $taxonomy,
+			'hide_empty' => false,
+			'number' => $number,
+			'offset' => $offset
+		);
+
 		//Populate the $author_terms(), so that we can pull out the applicable 'author-posts'
 		if ( ! empty( $request['parent_id'] ) ) {
 			$parent_id = (int) $request['parent_id'];
@@ -93,7 +106,7 @@ class WP_REST_CoAuthors_AuthorPosts extends WP_REST_Controller {
 		} else {
 			//Get all coauthor posts via the 'author' terms
 			//Bastardized from Co-Authors-Plus/template-tags.php (used there for users; changed here to authors)
-			$author_terms = get_terms( $this->coauthor_taxonomy );
+			$author_terms = get_terms( $query_args );
 		}
 
 
@@ -132,7 +145,19 @@ class WP_REST_CoAuthors_AuthorPosts extends WP_REST_Controller {
 
 		//Collected the posts, return them
 		if ( ! empty( $author_posts ) ) {
-			return rest_ensure_response( $author_posts );
+
+			$total_terms = wp_count_terms( $taxonomy, $query_args );
+			$max_pages = ceil( $total_terms / (int) $number + $offset );
+
+			$response = rest_ensure_response( $author_posts );
+
+			// Set the headers with the pagination info
+			$response->header( 'X-WP-Total', (int) $total_terms );
+			$response->header( 'X-WP-TotalPages', (int) $max_pages );
+
+			// Return the $response
+			return $response;
+
 		}
 
 		return new WP_Error( 'rest_co_authors_get_posts', __( 'Invalid authors id.' ), array( 'status' => 404 ) );

--- a/lib/inc/class-wp-rest-coauthors-authorterms.php
+++ b/lib/inc/class-wp-rest-coauthors-authorterms.php
@@ -222,7 +222,7 @@ class WP_REST_CoAuthors_AuthorTerms extends WP_REST_Controller {
 			'taxonomy' => $taxonomy,
 			'hide_empty' => false,
 			'number' => $number,
-			'offset' => $offset
+			'offset' => $offset,
 		);
 
 		if ( ! empty( $request['id_list'] ) ) {


### PR DESCRIPTION
This ensures the maximum results diplayed for the author posts and author terms endpoints is 100 items.

Additionally, it outputs info in the headers (like the other REST Endpoints) specifying the total number of items and the total number of pages.

So, now you can visit these endpoints:

`/wp-json/co-authors/v1/author-posts`
`/wp-json/co-authors/v1/author-terms`

And they will return a max of 100 items.

You can page through by adding offset and number as query params

For example:

`/wp-json/co-authors/v1/author-terms?number=100&offset=300` will show 100 items, skipping the first 300. (similar to `?posts_per_page=100&page=3`), but get_terms doesn't have "per_page" and "page" options, so this is the equivalent when querying terms.

If you inspect the headers of the requests, you'll see X-WP-Total (indicating the total number of items matching the query) and X-WP-TotalPages (indicating the total number of pages needed to read all possible items)

Let me know if you have any questions or whatever. . .once merged to this plugin, we'll need to update composer and the plugin in the mason repo.
